### PR TITLE
Customizable wiki index and diary index filenames (issue #5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ opts as a table that must include the following
 
 **index_filename**: A string containing wiki index file name (default value: `"Index.org"`)
 
+**diary_index_filename**: A string containing diary index file name (default value: `"Index.org"`)
+
 if you do not wish for the plugin to create the mappings you can use this option
 **disable_mappings** = true
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ opts as a table that must include the following
 
 **diary_path**: A string containing the path to the direcotry where diary entries must be stored
 
+**index_filename**: A string containing wiki index file name (default value: `"Index.org"`)
+
 if you do not wish for the plugin to create the mappings you can use this option
 **disable_mappings** = true
 

--- a/lua/orgWiki/diary.lua
+++ b/lua/orgWiki/diary.lua
@@ -1,7 +1,8 @@
 local diary = {}
 local exec = vim.api.nvim_command
 local diaryPath = vim.fn.expand(vim.g.orgwiki_diary_path)
-local diaryIndex = diaryPath .. "index.org"
+local diaryFileName = vim.fn.expand(vim.g.orgwiki_diary_index_filename)
+local diaryIndex = diaryPath .. diaryFileName
 
 local diaryHeader = [[#+:TITLE: OrgWiki Diary index file
 
@@ -165,7 +166,7 @@ end
 function diary.diaryIndexOpen(editcmd)
   local opencmd = editcmd and editcmd .. " " or "e "
   exec("cd " .. diaryPath)
-  vim.cmd(opencmd .. "index.org")
+  vim.cmd(opencmd .. diaryFileName)
 end
 
 return diary

--- a/lua/orgWiki/init.lua
+++ b/lua/orgWiki/init.lua
@@ -129,6 +129,12 @@ function orgwiki.setup(opts)
     vim.g.orgwiki_index_filename = "Index.org"
   end
 
+  if opts.diary_index_filename then
+    vim.g.orgwiki_diary_index_filename = opts.diary_index_filename
+  else
+    vim.g.orgwiki_diary_index_filename = "Index.org"
+  end
+
 
   if not opts.disable_mappings then
     if opts.keys then

--- a/lua/orgWiki/init.lua
+++ b/lua/orgWiki/init.lua
@@ -123,6 +123,12 @@ function orgwiki.setup(opts)
   end
 
   vim.g.orgwiki_filetypes = { "org", "norg" }
+  if opts.index_filename then
+    vim.g.orgwiki_index_filename = opts.index_filename
+  else
+    vim.g.orgwiki_index_filename = "Index.org"
+  end
+
 
   if not opts.disable_mappings then
     if opts.keys then

--- a/lua/orgWiki/wiki.lua
+++ b/lua/orgWiki/wiki.lua
@@ -4,6 +4,7 @@ local linkLines = {}
 local isIndexed = false
 
 local wikiPath = vim.g.orgwiki_path
+local wikiIndexFileName = vim.g.orgwiki_index_filename
 
 local current_wiki = ""
 local current_index
@@ -17,7 +18,7 @@ function wiki.openIndex(editcmd)
   local current_path = current_wiki ~= "" and current_wiki or wikiPath[1]
   current_wiki = current_path
   exec("cd " .. current_path)
-  exec(opencmd .. "Index.org")
+  exec(opencmd .. wikiIndexFileName)
 end
 
 ---If <cWORD> is not a hyperlink, create hyperlink interactively and jump to the link


### PR DESCRIPTION
Added `index_filename` and `diary_index_filename` options to set custom filenames for wiki index and diary index, both of them are set to "Index.org" by default to agree with current defaults.

`README.md` was updated accordingly.

[link to issue](https://github.com/ranjithshegde/orgWiki.nvim/issues/5)