### PR TITLE
[HOTFIX] Customizable wiki index and diary index filenames (issue #5)

### DIFF
--- a/doc/orgWiki.txt
+++ b/doc/orgWiki.txt
@@ -12,6 +12,8 @@ orgwiki.setup({opts})                                            *orgwiki.setup*
         {opts}  Table containing configuration options
 		• wiki_path: A list of directories to be recognized as orgWiki
 		• diary_path: A string containing the path to the direcotry where diary entries must be stored
+		• index_filename* A string containing wiki index file name (default value: `"Index.org"`)
+		• diary_index_filename: A string containing diary index file name (default value: `"Index.org"`)
 		• keys: optional table with values to set up keybindings. When any of the keys are omitted, default mappings are used
 		    • create_or_follow = `"<CR>"`, --  Follow hyperlink under cursor
 		    • traverse_back = `"<BS>"`, -- Return to the parent file or top of the link stack

--- a/lua/orgWiki/diary.lua
+++ b/lua/orgWiki/diary.lua
@@ -61,7 +61,7 @@ local getDiaryfiles = function()
   local result = {}
 
   for _, data in ipairs(list) do
-    if not string.find(data, "index") then
+    if not string.find(data, diaryFileName) then
       if data ~= "" then
         local ext = vim.fn.fnamemodify(data, ":e")
         if ext and ext == "org" then


### PR DESCRIPTION
Noticed that diary index generation has hardcoded "index" filename, so with previous changes regenerating a diary index might add a link to diary index itself. This commit fixes it.

[link to issue](https://github.com/ranjithshegde/orgWiki.nvim/issues/5)